### PR TITLE
Consistency in naming conventions

### DIFF
--- a/test/Registry/RecordExists.t.sol
+++ b/test/Registry/RecordExists.t.sol
@@ -13,7 +13,7 @@ contract RecordExists is RegistryBase {
         assertTrue(registry.recordExists(BASE_ETH_NODE));
     }
 
-    function text_correctlyConfirmsARecordDoesNotExist(bytes32 node) public view {
+    function test_correctlyConfirmsARecordDoesNotExist(bytes32 node) public view {
         vm.assume(node != BASE_ETH_NODE && node != ETH_NODE && node != bytes32(0));
         assertFalse(registry.recordExists(node));
     }


### PR DESCRIPTION
While the contract names (test_correctlyConfirmsARecordExists and test_correctlyConfirmsARecordDoesNotExist) are descriptive, using the prefix test_ consistently for test function names is helpful for clarity and better integration with test frameworks.