### PR TITLE
fix: Fixed unnecessary closing parenthesis Update EDAPrice.sol

### DIFF
--- a/src/lib/EDAPrice.sol
+++ b/src/lib/EDAPrice.sol
@@ -9,7 +9,7 @@ library EDAPrice {
     /// @dev reverts if perPeriodDecayPercentWad >= 1e18
     /// @dev reverts if uint256 secondsInPeriod = 0
     /// @dev reverts if startPrice * multiplier overflows
-    /// @dev reverts if lnWad(percentWadRemainingPerPeriod) * ratio) overflows
+    /// @dev reverts if lnWad(percentWadRemainingPerPeriod) * ratio overflows
 
     /// @param startPrice the starting price of the auction
     /// @param secondsElapsed the seconds elapsed since auction start


### PR DESCRIPTION
I’ve removed an extra closing parenthesis in the comment where the function description was incorrectly formatted.
The line in question was:

```
/// @dev reverts if lnWad(percentWadRemainingPerPeriod) * ratio) overflows
```

The additional parenthesis after `ratio` didn’t make sense and caused confusion.

Based!