### PR TITLE
typo fix BaseRegistrar.sol

### DIFF
--- a/src/L2/BaseRegistrar.sol
+++ b/src/L2/BaseRegistrar.sol
@@ -296,7 +296,7 @@ contract BaseRegistrar is ERC721, Ownable {
         return nameExpires[id] + GRACE_PERIOD < block.timestamp;
     }
 
-    /// @notice Allows holders of names to renew their ownerhsip and extend their expiry.
+    /// @notice Allows holders of names to renew their ownership and extend their expiry.
     ///
     /// @dev Renewal can be called while owning a subdomain or while the name is in the
     ///     grace period. Can only be called by a controller.


### PR DESCRIPTION
## Typo Fix in `BaseRegistrar.sol`

This pull request addresses a typographical error in the `BaseRegistrar.sol` file. The word "ownerhsip" has been corrected to "ownership."

### Changes:
- Fixed the typo from "ownerhsip" to "ownership" in a comment.

### Checklist:
- [x] Corrected the typographical error.
- [x] Changes reviewed and tested.
