### PR TITLE
feat: use stable foundry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Run Forge build
         run: |


### PR DESCRIPTION
Use stable version of foundry instead of the nightly
https://github.com/foundry-rs/foundry/releases/tag/v0.3.0