### PR TITLE
Fix typos

### DIFF
--- a/script/deploy/DeployL1Resolver.s.sol
+++ b/script/deploy/DeployL1Resolver.s.sol
@@ -7,7 +7,7 @@ import "src/L1/L1Resolver.sol";
 contract DeployL1Resolver is Script {
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        address deployerAddresss = vm.addr(deployerPrivateKey);
+        address deployerAddress = vm.addr(deployerPrivateKey);
         vm.startBroadcast(deployerPrivateKey);
 
         /// L1 Resolver constructor data
@@ -15,7 +15,7 @@ contract DeployL1Resolver is Script {
             "https://api-entry-gateway-development.cbhq.net/api/v1/subdomain/resolver/resolveDomain/{sender}/{data}"; //
         address[] memory signers = new address[](1);
         signers[0] = 0xa412c16ECd2198A6aBce8235651E105684Fb77ed; // DEV signer
-        address owner = deployerAddresss;
+        address owner = deployerAddress;
         address rootResolver = 0x8FADE66B79cC9f707aB26799354482EB93a5B7dD; //basetest.eth root resolver on sepolia
 
         L1Resolver l1 = new L1Resolver(url, signers, owner, rootResolver);

--- a/src/L1/L1Resolver.sol
+++ b/src/L1/L1Resolver.sol
@@ -187,7 +187,7 @@ contract L1Resolver is IExtendedResolver, ERC165, Ownable {
     /// @param response The response bytes that the client received from the gateway.
     /// @param extraData The additional bytes of information from the `OffchainLookup` `extraData` arg.
     ///
-    /// @return The bytes of the reponse from the CCIP read.
+    /// @return The bytes of the response from the CCIP read.
     function resolveWithProof(bytes calldata response, bytes calldata extraData) external view returns (bytes memory) {
         (address signer, bytes memory result) = SignatureVerifier.verify(extraData, response);
         if (!signers[signer]) revert InvalidSigner();

--- a/test/EARegistrarController/DiscountedRegister.t.sol
+++ b/test/EARegistrarController/DiscountedRegister.t.sol
@@ -32,7 +32,7 @@ contract DiscountedRegister is EARegistrarControllerBase {
         controller.discountedRegister{value: price}(_getDefaultRegisterRequest(), discountKey, "");
     }
 
-    function test_reverts_whenNameNotAvailble() public {
+    function test_reverts_whenNameNotAvailable() public {
         vm.deal(user, 1 ether);
         vm.prank(owner);
         controller.setDiscountDetails(_getDefaultDiscount());

--- a/test/RegistrarController/DiscountedRegister.t.sol
+++ b/test/RegistrarController/DiscountedRegister.t.sol
@@ -32,7 +32,7 @@ contract DiscountedRegister is RegistrarControllerBase {
         controller.discountedRegister{value: price}(_getDefaultRegisterRequest(), discountKey, "");
     }
 
-    function test_reverts_whenNameNotAvailble() public {
+    function test_reverts_whenNameNotAvailable() public {
         vm.deal(user, 1 ether);
         vm.prank(owner);
         controller.setDiscountDetails(_getDefaultDiscount());

--- a/test/RegistrarController/Register.t.sol
+++ b/test/RegistrarController/Register.t.sol
@@ -16,7 +16,7 @@ contract Register is RegistrarControllerBase {
         controller.register{value: price}(noResolverRequest);
     }
 
-    function test_reverts_whenNameNotAvailble() public {
+    function test_reverts_whenNameNotAvailable() public {
         vm.deal(user, 1 ether);
         uint256 price = controller.registerPrice(name, duration);
         base.setAvailable(uint256(nameLabel), false);


### PR DESCRIPTION
1. Fixed variable name typos in `DeployL1Resolver.s.sol` related to address variables (`deployerAddresss` to `deployerAddress`).
2. Corrected misspelled comments and function names in `L1Resolver.sol`.
3. Fixed the typo in the test functions in `DiscountedRegister.t.sol` and `Register.t.sol` by updating "NotAvailble" to "NotAvailable".
