### PR TITLE
Fix minor doc comment typos in L2Resolver and Registry

### DIFF
--- a/src/L2/L2Resolver.sol
+++ b/src/L2/L2Resolver.sol
@@ -65,7 +65,7 @@ contract L2Resolver is
     /*                          ERRORS                            */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-    /// @notice Thown when msg.sender tries to set itself as an operator.
+    /// @notice Thrown when msg.sender tries to set itself as an operator.
     error CantSetSelfAsOperator();
 
     /// @notice Thrown when msg.sender tries to set itself as a delegate for one of its names.

--- a/src/L2/Registry.sol
+++ b/src/L2/Registry.sol
@@ -202,7 +202,7 @@ contract Registry is ENS {
     /// @param owner_ The address that owns the records.
     /// @param operator The address that acts on behalf of the owner.
     ///
-    /// @return `true` if `operator` is an approved operator for `owner`, else `fase`.
+    /// @return `true` if `operator` is an approved operator for `owner`, else `false`.
     function isApprovedForAll(address owner_, address operator) external view virtual override returns (bool) {
         return _operators[owner_][operator];
     }


### PR DESCRIPTION
Pull Request Description

Corrected “Thown” → “Thrown” in L2Resolver.sol so the notice reflects the right word.
Corrected “fase” → “false” in Registry.sol to clarify the return value.
These changes are purely cosmetic and don’t affect any functionality.