### PR TITLE
Add ReverseRegistrarV2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Run Forge build
         run: |
           forge --version
-          forge build --sizes
         id: build
 
       - name: Run Forge tests

--- a/src/L2/ReverseRegistrarV2.sol
+++ b/src/L2/ReverseRegistrarV2.sol
@@ -119,17 +119,18 @@ contract ReverseRegistrarV2 is Ownable {
     /// @notice Sets the reverse record `name` for `addr`.
     ///
     /// @dev First calls the ENS L2ReverseRegistrar and sets the name-record for the provided address. Then follows the legacy
-    ///     Basenames reverse registrar flow.
+    ///     Basenames reverse registrar flow. The call to the L2ReverseRegistrar will revert if the signature is invalid or
+    ///     if the signature is expired.
     ///
     /// @param addr The name records will be set for this address.
-    /// @param name The name that will be stored for `addr`.
     /// @param signatureExpiry The timestamp expiration of the signature.
+    /// @param name The name that will be stored for `addr`.
     /// @param cointypes The array of networks-as-cointypes used in replayable reverse sets.
     /// @param signature The signature bytes.
     function setNameForAddrWithSignature(
         address addr,
-        string calldata name,
         uint256 signatureExpiry,
+        string calldata name,
         uint256[] memory cointypes,
         bytes memory signature
     ) external returns (bytes32) {

--- a/src/L2/ReverseRegistrarV2.sol
+++ b/src/L2/ReverseRegistrarV2.sol
@@ -264,6 +264,12 @@ contract ReverseRegistrarV2 is Ownable {
         }
     }
 
+    /// @notice Helper for converting an address stored as bytes into an address type.
+    ///
+    /// @dev Copied from ENS `AddrResolver`:
+    ///     https://github.com/ensdomains/ens-contracts/blob/staging/contracts/resolvers/profiles/AddrResolver.sol
+    ///
+    /// @param b Address bytes.
     function _bytesToAddress(bytes memory b) internal pure returns (address payable a) {
         require(b.length == 20);
         assembly {
@@ -271,6 +277,12 @@ contract ReverseRegistrarV2 is Ownable {
         }
     }
 
+    /// @notice Helper for converting an address into a bytes object.
+    ///
+    /// @dev Copied from ENS `AddrResolver`:
+    ///     https://github.com/ensdomains/ens-contracts/blob/staging/contracts/resolvers/profiles/AddrResolver.sol
+    ///
+    /// @param a Address.
     function _addressToBytes(address a) internal pure returns (bytes memory b) {
         b = new bytes(20);
         assembly {

--- a/src/L2/ReverseRegistrarV2.sol
+++ b/src/L2/ReverseRegistrarV2.sol
@@ -28,7 +28,7 @@ contract ReverseRegistrarV2 is Ownable {
     /// @notice The reverse node this registrar manages.
     bytes32 public immutable reverseNode;
 
-    /// @notice The network cointype. 
+    /// @notice The network cointype.
     uint256 public immutable cointype;
 
     /// @notice Permissioned controller contracts.
@@ -103,7 +103,7 @@ contract ReverseRegistrarV2 is Ownable {
     /// @param registry_ The ENS registry, will be stored as `registry`.
     /// @param owner_ The permissioned address initialized as the `owner` in the `Ownable` context.
     /// @param reverseNode_ The network-sepcific reverse node.
-    /// @param cointype_ The network-specific cointype. 
+    /// @param cointype_ The network-specific cointype.
     constructor(ENS registry_, address owner_, bytes32 reverseNode_, uint256 cointype_) {
         _initializeOwner(owner_);
         registry = registry_;
@@ -111,33 +111,32 @@ contract ReverseRegistrarV2 is Ownable {
         cointype = cointype_;
     }
 
-
     /// @notice Allows the owner to back populate the ENSIP-11 forward resolution records for basenames.
     ///
     /// @dev For each node in `nodes` we make a series of checks to make sure that we're
     ///     1. Trying to set data against our L2Resolver contract.
     ///     2. Setting a valid forward resolution address.
     ///     3. Not overwriting an existing value.
-    ///     If any of these checks fails, we skip this node and continue. 
+    ///     If any of these checks fails, we skip this node and continue.
     ///
     /// @param nodes The array of nodes for which records will be set.
     function setBaseForwardAddr(bytes32[] memory nodes) public onlyOwner {
-        for(uint256 i; i < nodes.length; i++) {
+        for (uint256 i; i < nodes.length; i++) {
             bytes32 _node = nodes[i];
 
             // Get the resolver address for the node and check that it is our public resolver.
-            address resolverAddr  = registry.resolver(_node);
-            if (address(resolverAddr) != address(defaultResolver)) { continue; }
+            address resolverAddr = registry.resolver(_node);
+            if (address(resolverAddr) != address(defaultResolver)) continue;
             AddrResolver resolver = AddrResolver(resolverAddr);
 
-            // Get the `addr` record for the node and check validity. 
+            // Get the `addr` record for the node and check validity.
             address resolvedAddr = resolver.addr(_node);
-            if (resolvedAddr == address(0)) { continue; }
+            if (resolvedAddr == address(0)) continue;
 
-            // Check if there is an ENSIP-11 cointype address already set for this node. 
-            if (_bytesToAddress(resolver.addr(_node, cointype)) != address(0)) { continue; } 
-            
-            // Set the ENSIP-11 forward resolution addr. 
+            // Check if there is an ENSIP-11 cointype address already set for this node.
+            if (_bytesToAddress(resolver.addr(_node, cointype)) != address(0)) continue;
+
+            // Set the ENSIP-11 forward resolution addr.
             resolver.setAddr(_node, cointype, _addressToBytes(resolvedAddr));
         }
     }
@@ -265,9 +264,7 @@ contract ReverseRegistrarV2 is Ownable {
         }
     }
 
-    function _bytesToAddress(
-        bytes memory b
-    ) internal pure returns (address payable a) {
+    function _bytesToAddress(bytes memory b) internal pure returns (address payable a) {
         require(b.length == 20);
         assembly {
             a := div(mload(add(b, 32)), exp(256, 12))

--- a/src/L2/ReverseRegistrarV2.sol
+++ b/src/L2/ReverseRegistrarV2.sol
@@ -293,19 +293,6 @@ contract ReverseRegistrarV2 is Ownable {
         }
     }
 
-    /// @notice Helper for converting an address stored as bytes into an address type.
-    ///
-    /// @dev Copied from ENS `AddrResolver`:
-    ///     https://github.com/ensdomains/ens-contracts/blob/staging/contracts/resolvers/profiles/AddrResolver.sol
-    ///
-    /// @param b Address bytes.
-    function _bytesToAddress(bytes memory b) internal pure returns (address payable a) {
-        require(b.length == 20);
-        assembly {
-            a := div(mload(add(b, 32)), exp(256, 12))
-        }
-    }
-
     /// @notice Helper for converting an address into a bytes object.
     ///
     /// @dev Copied from ENS `AddrResolver`:

--- a/src/L2/ReverseRegistrarV2.sol
+++ b/src/L2/ReverseRegistrarV2.sol
@@ -1,0 +1,283 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ENS} from "ens-contracts/registry/ENS.sol";
+import {NameResolver} from "ens-contracts/resolvers/profiles/NameResolver.sol";
+import {AddrResolver} from "ens-contracts/resolvers/profiles/AddrResolver.sol";
+import {Ownable} from "solady/auth/Ownable.sol";
+
+import {Sha3} from "src/lib/Sha3.sol";
+
+/// @title Reverse Registrar V2
+///
+/// @notice Registrar which allows registrants to establish a name as their "primary" record for reverse resolution.
+///         Inspired by ENS's ReverseRegistrar implementation:
+///         https://github.com/ensdomains/ens-contracts/blob/staging/contracts/reverseRegistrar/ReverseRegistrar.sol
+///         Writes records to the network-specific reverse node set on construction via `reverseNode`.
+///         Compliant with ENSIP-19: https://docs.ens.domains/ensip/19
+///
+/// @author Coinbase (https://github.com/base/basenames)
+contract ReverseRegistrarV2 is Ownable {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          STORAGE                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice The Registry contract.
+    ENS public immutable registry;
+
+    /// @notice The reverse node this registrar manages.
+    bytes32 public immutable reverseNode;
+
+    /// @notice The network cointype. 
+    uint256 public immutable cointype;
+
+    /// @notice Permissioned controller contracts.
+    mapping(address controller => bool approved) public controllers;
+
+    /// @notice The default resolver for setting Name resolution records.
+    NameResolver public defaultResolver;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          ERRORS                            */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Thrown when `sender` is not authorized to modify records for `addr`.
+    ///
+    /// @param addr The `addr` that was being modified.
+    /// @param sender The unauthorized sender.
+    error NotAuthorized(address addr, address sender);
+
+    /// @notice Thrown when trying to set the zero address as the default resolver.
+    error NoZeroAddress();
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          EVENTS                            */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Emitted upon successfully establishing a base-specific reverse record.
+    ///
+    /// @param addr The address for which the the record was set.
+    /// @param node  The namehashed node that was set as the base reverse record.
+    event BaseReverseClaimed(address indexed addr, bytes32 indexed node);
+
+    /// @notice Emitted when the default Resolver is changed by the `owner`.
+    ///
+    /// @param resolver The address of the new Resolver.
+    event DefaultResolverChanged(NameResolver indexed resolver);
+
+    /// @notice Emitted when a controller address approval status is changed by the `owner`.
+    ///
+    /// @param controller The address of the `controller`.
+    /// @param approved The new approval state for the `controller` address.
+    event ControllerApprovalChanged(address indexed controller, bool approved);
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          MODIFIERS                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Decorator for checking authorization status for a caller against a provided `addr`.
+    ///
+    /// @dev A caller is authorized to set the record for `addr` if they are one of:
+    ///     1. The `addr` is the sender
+    ///     2. The sender is an approved `controller`
+    ///     3. The sender is an approved operator for `addr` on the registry
+    ///     4. The sender is `Ownable:ownerOf()` for `addr`
+    ///
+    /// @param addr The `addr` that is being modified.
+    modifier authorized(address addr) {
+        if (
+            addr != msg.sender && !controllers[msg.sender] && !registry.isApprovedForAll(addr, msg.sender)
+                && !_ownsContract(addr)
+        ) {
+            revert NotAuthorized(addr, msg.sender);
+        }
+        _;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        IMPLEMENTATION                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice ReverseRegistrar construction.
+    ///
+    /// @param registry_ The ENS registry, will be stored as `registry`.
+    /// @param owner_ The permissioned address initialized as the `owner` in the `Ownable` context.
+    /// @param reverseNode_ The network-sepcific reverse node.
+    /// @param cointype_ The network-specific cointype. 
+    constructor(ENS registry_, address owner_, bytes32 reverseNode_, uint256 cointype_) {
+        _initializeOwner(owner_);
+        registry = registry_;
+        reverseNode = reverseNode_;
+        cointype = cointype_;
+    }
+
+
+    /// @notice Allows the owner to back populate the ENSIP-11 forward resolution records for basenames.
+    ///
+    /// @dev For each node in `nodes` we make a series of checks to make sure that we're
+    ///     1. Trying to set data against our L2Resolver contract.
+    ///     2. Setting a valid forward resolution address.
+    ///     3. Not overwriting an existing value.
+    ///     If any of these checks fails, we skip this node and continue. 
+    ///
+    /// @param nodes The array of nodes for which records will be set.
+    function setBaseForwardAddr(bytes32[] memory nodes) public onlyOwner {
+        for(uint256 i; i < nodes.length; i++) {
+            bytes32 _node = nodes[i];
+
+            // Get the resolver address for the node and check that it is our public resolver.
+            address resolverAddr  = registry.resolver(_node);
+            if (address(resolverAddr) != address(defaultResolver)) { continue; }
+            AddrResolver resolver = AddrResolver(resolverAddr);
+
+            // Get the `addr` record for the node and check validity. 
+            address resolvedAddr = resolver.addr(_node);
+            if (resolvedAddr == address(0)) { continue; }
+
+            // Check if there is an ENSIP-11 cointype address already set for this node. 
+            if (_bytesToAddress(resolver.addr(_node, cointype)) != address(0)) { continue; } 
+            
+            // Set the ENSIP-11 forward resolution addr. 
+            resolver.setAddr(_node, cointype, _addressToBytes(resolvedAddr));
+        }
+    }
+
+    /// @notice Allows the owner to change the address of the default resolver.
+    ///
+    /// @dev The address of the new `resolver` must not be the zero address.
+    ///     Emits `DefaultResolverChanged` after successfully storing `resolver` as `defaultResolver`.
+    ///
+    /// @param resolver The address of the new resolver.
+    function setDefaultResolver(address resolver) public onlyOwner {
+        if (address(resolver) == address(0)) revert NoZeroAddress();
+        defaultResolver = NameResolver(resolver);
+        registry.setResolver(reverseNode, resolver);
+        emit DefaultResolverChanged(defaultResolver);
+    }
+
+    /// @notice Allows the owner to change the approval status of an address as a controller.
+    ///
+    /// @param controller The address of the controller.
+    /// @param approved Whether the controller has permissions to modify reverse records.
+    function setControllerApproval(address controller, bool approved) public onlyOwner {
+        if (controller == address(0)) revert NoZeroAddress();
+        controllers[controller] = approved;
+        emit ControllerApprovalChanged(controller, approved);
+    }
+
+    /// @notice Transfers ownership of the base-specific reverse ENS record for `msg.sender` to the provided `owner`.
+    ///
+    /// @param owner The address to set as the owner of the reverse record in ENS.
+    ///
+    /// @return The ENS node hash of the base-specific reverse record.
+    function claim(address owner) public returns (bytes32) {
+        return claimForBaseAddr(msg.sender, owner, address(defaultResolver));
+    }
+
+    /// @notice Transfers ownership of the base-specific reverse ENS record for `addr` to the provided `owner`.
+    ///
+    /// @dev Restricted to only `authorized` owners/operators of `addr`.
+    ///     Emits `BaseReverseClaimed` after successfully transfering ownership of the reverse record.
+    ///
+    /// @param addr The reverse record to set.
+    /// @param owner The new owner of the reverse record in ENS.
+    /// @param resolver The address of the resolver to set.
+    ///
+    /// @return The ENS node hash of the base-specific reverse record.
+    function claimForBaseAddr(address addr, address owner, address resolver)
+        public
+        authorized(addr)
+        returns (bytes32)
+    {
+        bytes32 labelHash = Sha3.hexAddress(addr);
+        bytes32 baseReverseNode = keccak256(abi.encodePacked(reverseNode, labelHash));
+        emit BaseReverseClaimed(addr, baseReverseNode);
+        registry.setSubnodeRecord(reverseNode, labelHash, owner, resolver, 0);
+        return baseReverseNode;
+    }
+
+    /// @notice Transfers ownership and sets the resolver of the reverse ENS record for `addr` to the provided `owner`.
+    ///
+    /// @param owner The address to set as the owner of the reverse record in ENS.
+    /// @param resolver The address of the resolver to set.
+    ///
+    /// @return The ENS node hash of the base-specific reverse record.
+    function claimWithResolver(address owner, address resolver) public returns (bytes32) {
+        return claimForBaseAddr(msg.sender, owner, resolver);
+    }
+
+    /// @notice Set the `name()` record for the reverse ENS record associated with the calling account.
+    ///
+    /// @dev This call will first updates the resolver to the default reverse resolver if necessary.
+    ///
+    /// @param name The name to set for msg.sender.
+    ///
+    /// @return The ENS node hash of the reverse record.
+    function setName(string memory name) public returns (bytes32) {
+        return setNameForAddr(msg.sender, msg.sender, address(defaultResolver), name);
+    }
+
+    /// @notice Sets the `name()` record for the reverse ENS records associated with the `addr` provided.
+    ///
+    /// @dev Updates the resolver to a designated resolver. Only callable by `addr`'s `authroized` addresses.
+    ///
+    /// @param addr The reverse record to set.
+    /// @param owner The owner of the reverse node.
+    /// @param resolver The resolver of the reverse node.
+    /// @param name The name to set for this address.
+    ///
+    /// @return The ENS node hash of the `baseAsCoinType.reverse` record.
+    function setNameForAddr(address addr, address owner, address resolver, string memory name)
+        public
+        returns (bytes32)
+    {
+        bytes32 baseNode_ = claimForBaseAddr(addr, owner, resolver);
+        NameResolver(resolver).setName(baseNode_, name);
+
+        return baseNode_;
+    }
+
+    /// @notice Returns the node hash for a provided `addr`'s reverse records.
+    ///
+    /// @param addr The address to hash.
+    ///
+    /// @return The base-specific reverse node hash.
+    function node(address addr) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(reverseNode, Sha3.hexAddress(addr)));
+    }
+
+    /// @notice Allows this contract to check if msg.sender is the `Ownable:owner()` for `addr`.
+    ///
+    /// @dev First checks if `addr` is a contract and returns early if not. Then uses a `try/except` to
+    ///     see if `addr` responds with a valid address.
+    ///
+    /// @return `true` if the address returned from `Ownable:owner()` == msg.sender, else `false`.
+    function _ownsContract(address addr) internal view returns (bool) {
+        // Determine if a contract exists at `addr` and return early if not
+        if (addr.code.length == 0) {
+            return false;
+        }
+        // If a contract does exist, try and call `Ownable.owner()`
+        try Ownable(addr).owner() returns (address owner) {
+            return owner == msg.sender;
+        } catch {
+            return false;
+        }
+    }
+
+    function _bytesToAddress(
+        bytes memory b
+    ) internal pure returns (address payable a) {
+        require(b.length == 20);
+        assembly {
+            a := div(mload(add(b, 32)), exp(256, 12))
+        }
+    }
+
+    function _addressToBytes(address a) internal pure returns (bytes memory b) {
+        b = new bytes(20);
+        assembly {
+            mstore(add(b, 32), mul(a, exp(256, 12)))
+        }
+    }
+}

--- a/src/L2/ReverseRegistrarV2.sol
+++ b/src/L2/ReverseRegistrarV2.sol
@@ -163,7 +163,7 @@ contract ReverseRegistrarV2 is Ownable {
             if (resolvedAddr == address(0)) continue;
 
             // Check if there is an ENSIP-11 cointype address already set for this node.
-            if (_bytesToAddress(resolver.addr(_node, cointype)) != address(0)) continue;
+            if (resolver.addr(_node, cointype).length != 0) continue;
 
             // Set the ENSIP-11 forward resolution addr.
             resolver.setAddr(_node, cointype, _addressToBytes(resolvedAddr));

--- a/src/L2/interface/IL2ReverseRegistrar.sol
+++ b/src/L2/interface/IL2ReverseRegistrar.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/// @notice Interface for the L2 Reverse Registrar.
+interface IL2ReverseRegistrar {
+    /// @notice Sets the `nameForAddr()` record for the calling account.
+    ///
+    /// @param name The name to set.
+    function setName(string memory name) external;
+
+    /// @notice Sets the `nameForAddr()` record for the addr provided account.
+    ///
+    /// @param addr The address to set the name for.
+    /// @param name The name to set.
+    function setNameForAddr(address addr, string memory name) external;
+
+    /// @notice Sets the `nameForAddr()` record for the addr provided account using a signature.
+    ///
+    /// @param addr The address to set the name for.
+    /// @param name The name to set.
+    /// @param coinTypes The coin types to set. Must be inclusive of the coin type for the contract.
+    /// @param signatureExpiry Date when the signature expires.
+    /// @param signature The signature from the addr.
+    function setNameForAddrWithSignature(
+        address addr,
+        uint256 signatureExpiry,
+        string memory name,
+        uint256[] memory coinTypes,
+        bytes memory signature
+    ) external;
+
+    /// @notice Sets the `nameForAddr()` record for the contract provided that is owned with `Ownable`.
+    ///
+    /// @param contractAddr The address of the contract to set the name for (implementing Ownable).
+    /// @param owner The owner of the contract (via Ownable).
+    /// @param signatureExpiry The expiry of the signature.
+    /// @param name The name to set.
+    /// @param coinTypes The coin types to set. Must be inclusive of the coin type for the contract.
+    /// @param signature The signature of an address that will return true on isValidSignature for the owner.
+    function setNameForOwnableWithSignature(
+        address contractAddr,
+        address owner,
+        uint256 signatureExpiry,
+        string memory name,
+        uint256[] memory coinTypes,
+        bytes memory signature
+    ) external;
+}

--- a/src/L2/interface/IL2ReverseRegistrar.sol
+++ b/src/L2/interface/IL2ReverseRegistrar.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 /// @notice Interface for the L2 Reverse Registrar.
+///     https://github.com/ensdomains/ens-contracts/pull/265
 interface IL2ReverseRegistrar {
     /// @notice Sets the `nameForAddr()` record for the calling account.
     ///
@@ -17,9 +18,9 @@ interface IL2ReverseRegistrar {
     /// @notice Sets the `nameForAddr()` record for the addr provided account using a signature.
     ///
     /// @param addr The address to set the name for.
+    /// @param signatureExpiry Date when the signature expires.
     /// @param name The name to set.
     /// @param coinTypes The coin types to set. Must be inclusive of the coin type for the contract.
-    /// @param signatureExpiry Date when the signature expires.
     /// @param signature The signature from the addr.
     function setNameForAddrWithSignature(
         address addr,

--- a/test/ReverseRegistrarV2/Claim.t.sol
+++ b/test/ReverseRegistrarV2/Claim.t.sol
@@ -1,0 +1,29 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ReverseRegistrarV2Base} from "./ReverseRegistrarV2Base.t.sol";
+import {ReverseRegistrarV2} from "src/L2/ReverseRegistrarV2.sol";
+import {Sha3} from "src/lib/Sha3.sol";
+import {BASE_REVERSE_NODE} from "src/util/Constants.sol";
+
+contract Claim is ReverseRegistrarV2Base {
+    function test_allowsUser_toClaim() public {
+        bytes32 labelHash = Sha3.hexAddress(user);
+        bytes32 baseReverseNode = keccak256(abi.encodePacked(BASE_REVERSE_NODE, labelHash));
+
+        vm.prank(owner);
+        reverse.setDefaultResolver(address(resolver));
+
+        vm.expectEmit(address(reverse));
+        emit ReverseRegistrarV2.BaseReverseClaimed(user, baseReverseNode);
+
+        vm.prank(user);
+        bytes32 returnedReverseNode = reverse.claim(user);
+
+        assertTrue(baseReverseNode == returnedReverseNode);
+        address retBaseOwner = registry.owner(baseReverseNode);
+        assertTrue(retBaseOwner == user);
+        address retBaseResolver = registry.resolver(baseReverseNode);
+        assertTrue(retBaseResolver == address(resolver));
+    }
+}

--- a/test/ReverseRegistrarV2/ClaimForBaseAddr.t.sol
+++ b/test/ReverseRegistrarV2/ClaimForBaseAddr.t.sol
@@ -1,0 +1,66 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ReverseRegistrarV2Base} from "./ReverseRegistrarV2Base.t.sol";
+import {ReverseRegistrarV2} from "src/L2/ReverseRegistrarV2.sol";
+import {Sha3} from "src/lib/Sha3.sol";
+import {BASE_REVERSE_NODE} from "src/util/Constants.sol";
+import {MockOwnedContract} from "test/mocks/MockOwnedContract.sol";
+
+contract ClaimForBaseAddr is ReverseRegistrarV2Base {
+    function test_reverts_ifNotAuthorized() public {
+        address revRecordAddr = makeAddr("revRecord");
+        vm.expectRevert(abi.encodeWithSelector(ReverseRegistrarV2.NotAuthorized.selector, revRecordAddr, user));
+        vm.prank(user);
+        reverse.claimForBaseAddr(revRecordAddr, user, address(resolver));
+    }
+
+    function test_allowsUser_toclaimForBaseAddr_forUserAddress() public {
+        bytes32 labelHash = Sha3.hexAddress(user);
+        bytes32 reverseNode = keccak256(abi.encodePacked(BASE_REVERSE_NODE, labelHash));
+
+        vm.expectEmit(address(reverse));
+        emit ReverseRegistrarV2.BaseReverseClaimed(user, reverseNode);
+        vm.prank(user);
+        bytes32 returnedReverseNode = reverse.claimForBaseAddr(user, user, address(resolver));
+        assertTrue(reverseNode == returnedReverseNode);
+        address retOwner = registry.owner(reverseNode);
+        assertTrue(retOwner == user);
+        address retResolver = registry.resolver(reverseNode);
+        assertTrue(retResolver == address(resolver));
+    }
+
+    function test_allowsOperator_toclaimForBaseAddr_forUserAddress() public {
+        bytes32 labelHash = Sha3.hexAddress(user);
+        bytes32 reverseNode = keccak256(abi.encodePacked(BASE_REVERSE_NODE, labelHash));
+        address operator = makeAddr("operator");
+        vm.prank(user);
+        registry.setApprovalForAll(operator, true);
+
+        vm.expectEmit(address(reverse));
+        emit ReverseRegistrarV2.BaseReverseClaimed(user, reverseNode);
+        vm.prank(operator);
+        bytes32 returnedReverseNode = reverse.claimForBaseAddr(user, user, address(resolver));
+        assertTrue(reverseNode == returnedReverseNode);
+        address retOwner = registry.owner(reverseNode);
+        assertTrue(retOwner == user);
+        address retResolver = registry.resolver(reverseNode);
+        assertTrue(retResolver == address(resolver));
+    }
+
+    function test_allowsOwnerOfContract_toclaimForBaseAddr_forOwnedContractAddress() public {
+        MockOwnedContract ownedContract = new MockOwnedContract(user);
+        bytes32 labelHash = Sha3.hexAddress(address(ownedContract));
+        bytes32 reverseNode = keccak256(abi.encodePacked(BASE_REVERSE_NODE, labelHash));
+
+        vm.expectEmit(address(reverse));
+        emit ReverseRegistrarV2.BaseReverseClaimed(address(ownedContract), reverseNode);
+        vm.prank(user);
+        bytes32 returnedReverseNode = reverse.claimForBaseAddr(address(ownedContract), user, address(resolver));
+        assertTrue(reverseNode == returnedReverseNode);
+        address retOwner = registry.owner(reverseNode);
+        assertTrue(retOwner == user);
+        address retResolver = registry.resolver(reverseNode);
+        assertTrue(retResolver == address(resolver));
+    }
+}

--- a/test/ReverseRegistrarV2/ClaimWithResolver.t.sol
+++ b/test/ReverseRegistrarV2/ClaimWithResolver.t.sol
@@ -1,0 +1,24 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ReverseRegistrarV2Base} from "./ReverseRegistrarV2Base.t.sol";
+import {ReverseRegistrarV2} from "src/L2/ReverseRegistrarV2.sol";
+import {Sha3} from "src/lib/Sha3.sol";
+import {BASE_REVERSE_NODE} from "src/util/Constants.sol";
+
+contract ClaimWithResolver is ReverseRegistrarV2Base {
+    function test_allowsUser_toClaimWithResolver() public {
+        bytes32 labelHash = Sha3.hexAddress(user);
+        bytes32 reverseNode = keccak256(abi.encodePacked(BASE_REVERSE_NODE, labelHash));
+
+        vm.expectEmit(address(reverse));
+        emit ReverseRegistrarV2.BaseReverseClaimed(user, reverseNode);
+        vm.prank(user);
+        bytes32 returnedReverseNode = reverse.claimWithResolver(user, address(resolver));
+        assertTrue(reverseNode == returnedReverseNode);
+        address retOwner = registry.owner(reverseNode);
+        assertTrue(retOwner == user);
+        address retResolver = registry.resolver(reverseNode);
+        assertTrue(retResolver == address(resolver));
+    }
+}

--- a/test/ReverseRegistrarV2/Node.t.sol
+++ b/test/ReverseRegistrarV2/Node.t.sol
@@ -1,0 +1,15 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ReverseRegistrarV2Base} from "./ReverseRegistrarV2Base.t.sol";
+import {Sha3} from "src/lib/Sha3.sol";
+import {BASE_REVERSE_NODE} from "src/util/Constants.sol";
+
+contract Node is ReverseRegistrarV2Base {
+    function test_returnsExpectedNode(address addr) public view {
+        bytes32 labelHash = Sha3.hexAddress(addr);
+        bytes32 expectedNode = keccak256(abi.encodePacked(BASE_REVERSE_NODE, labelHash));
+        bytes32 retNode = reverse.node(addr);
+        assertTrue(retNode == expectedNode);
+    }
+}

--- a/test/ReverseRegistrarV2/ReverseRegistrarV2Base.t.sol
+++ b/test/ReverseRegistrarV2/ReverseRegistrarV2Base.t.sol
@@ -22,17 +22,12 @@ contract ReverseRegistrarV2Base is Test {
     uint256 constant BASE_COINTYPE = 0x80000000 | 0x00002105;
     string name = "name";
 
-
     function setUp() public {
         registry = new Registry(owner);
         l2ReverseRegistrar = new MockL2ReverseRegistrar();
         resolver = new MockNameResolver();
         reverse = new ReverseRegistrarV2(
-            ENS(address(registry)),
-            owner,
-            BASE_REVERSE_NODE,
-            address(l2ReverseRegistrar),
-            BASE_COINTYPE
+            ENS(address(registry)), owner, BASE_REVERSE_NODE, address(l2ReverseRegistrar), BASE_COINTYPE
         );
         vm.prank(owner);
         reverse.setControllerApproval(controller, true);
@@ -52,11 +47,7 @@ contract ReverseRegistrarV2Base is Test {
         vm.prank(owner);
         registry.setSubnodeOwner(0x0, keccak256("reverse"), owner);
         vm.prank(owner);
-        registry.setSubnodeOwner(
-            REVERSE_NODE,
-            keccak256("80002105"),
-            address(reverse)
-        );
+        registry.setSubnodeOwner(REVERSE_NODE, keccak256("80002105"), address(reverse));
     }
 
     function test_constructor() public view {

--- a/test/ReverseRegistrarV2/ReverseRegistrarV2Base.t.sol
+++ b/test/ReverseRegistrarV2/ReverseRegistrarV2Base.t.sol
@@ -1,0 +1,67 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {ReverseRegistrarV2} from "src/L2/ReverseRegistrarV2.sol";
+import {Registry} from "src/L2/Registry.sol";
+import {ENS} from "ens-contracts/registry/ENS.sol";
+import {MockL2ReverseRegistrar} from "test/mocks/MockL2ReverseRegistrar.sol";
+import {MockNameResolver} from "test/mocks/MockNameResolver.sol";
+import {ETH_NODE, REVERSE_NODE, BASE_REVERSE_NODE} from "src/util/Constants.sol";
+
+contract ReverseRegistrarV2Base is Test {
+    address public owner = makeAddr("owner");
+    address public user = makeAddr("user");
+    address public controller = makeAddr("controller");
+
+    Registry public registry;
+    ReverseRegistrarV2 public reverse;
+    MockL2ReverseRegistrar public l2ReverseRegistrar;
+    MockNameResolver public resolver;
+
+    uint256 constant BASE_COINTYPE = 0x80000000 | 0x00002105;
+    string name = "name";
+
+
+    function setUp() public {
+        registry = new Registry(owner);
+        l2ReverseRegistrar = new MockL2ReverseRegistrar();
+        resolver = new MockNameResolver();
+        reverse = new ReverseRegistrarV2(
+            ENS(address(registry)),
+            owner,
+            BASE_REVERSE_NODE,
+            address(l2ReverseRegistrar),
+            BASE_COINTYPE
+        );
+        vm.prank(owner);
+        reverse.setControllerApproval(controller, true);
+        _registrySetup();
+    }
+
+    function _registrySetup() internal virtual {
+        // establish the base.eth namespace
+        bytes32 ethLabel = keccak256("eth");
+        bytes32 baseLabel = keccak256("base");
+        vm.prank(owner);
+        registry.setSubnodeOwner(0x0, ethLabel, owner);
+        vm.prank(owner);
+        registry.setSubnodeOwner(ETH_NODE, baseLabel, owner);
+
+        // establish the 80002105.reverse namespace
+        vm.prank(owner);
+        registry.setSubnodeOwner(0x0, keccak256("reverse"), owner);
+        vm.prank(owner);
+        registry.setSubnodeOwner(
+            REVERSE_NODE,
+            keccak256("80002105"),
+            address(reverse)
+        );
+    }
+
+    function test_constructor() public view {
+        assertTrue(reverse.owner() == owner);
+        assertTrue(address(reverse.registry()) == address(registry));
+        assertTrue(reverse.controllers(controller));
+    }
+}

--- a/test/ReverseRegistrarV2/ReverseRegistrarV2Base.t.sol
+++ b/test/ReverseRegistrarV2/ReverseRegistrarV2Base.t.sol
@@ -22,7 +22,7 @@ contract ReverseRegistrarV2Base is Test {
     uint256 constant BASE_COINTYPE = 0x80000000 | 0x00002105;
     string name = "name";
 
-    function setUp() public {
+    function setUp() public virtual {
         registry = new Registry(owner);
         l2ReverseRegistrar = new MockL2ReverseRegistrar();
         resolver = new MockNameResolver();
@@ -48,11 +48,5 @@ contract ReverseRegistrarV2Base is Test {
         registry.setSubnodeOwner(0x0, keccak256("reverse"), owner);
         vm.prank(owner);
         registry.setSubnodeOwner(REVERSE_NODE, keccak256("80002105"), address(reverse));
-    }
-
-    function test_constructor() public view {
-        assertTrue(reverse.owner() == owner);
-        assertTrue(address(reverse.registry()) == address(registry));
-        assertTrue(reverse.controllers(controller));
     }
 }

--- a/test/ReverseRegistrarV2/SetBaseForwardAddr.t.sol
+++ b/test/ReverseRegistrarV2/SetBaseForwardAddr.t.sol
@@ -1,0 +1,129 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ReverseRegistrarV2Base} from "./ReverseRegistrarV2Base.t.sol";
+import {ReverseRegistrarV2} from "src/L2/ReverseRegistrarV2.sol";
+import {Sha3} from "src/lib/Sha3.sol";
+import {BASE_ETH_NODE} from "src/util/Constants.sol";
+import {MockAddrResolver} from "test/mocks/MockAddrResolver.sol";
+import {Ownable} from "solady/auth/Ownable.sol";
+
+import {console} from "forge-std/console.sol";
+
+contract SetBaseForwardAddr is ReverseRegistrarV2Base {
+    MockAddrResolver addrResolver;
+    bytes32 fwdNode;
+
+    function setUp() public override {
+        super.setUp();
+        addrResolver = new MockAddrResolver();
+
+        _setupRegistry();
+
+        vm.prank(owner);
+        reverse.setDefaultResolver(address(addrResolver));
+    }
+
+    function test_reverts_whenCalledByNonOwner(address caller) public {
+        vm.assume(caller != owner);
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        vm.prank(caller);
+        reverse.setDefaultResolver(makeAddr("fake"));
+    }
+
+    function test_continuesWhen_resolverIsNotDefaultResolver() public {
+        // Set resolver to user's own address
+        vm.prank(user);
+        registry.setResolver(fwdNode, user);
+
+        vm.prank(owner);
+        reverse.setBaseForwardAddr(_getNodes());
+
+        bytes memory retAddr = addrResolver.addr(fwdNode, BASE_COINTYPE);
+        assertEq(keccak256(retAddr), keccak256(""));
+    }
+
+    function test_continuesWhen_resolvedAddrIsInvalid() public {
+        // Set resolver to addr resolver address
+        vm.prank(user);
+        registry.setResolver(fwdNode, address(addrResolver));
+
+        vm.prank(owner);
+        reverse.setBaseForwardAddr(_getNodes());
+
+        bytes memory retAddr = addrResolver.addr(fwdNode, BASE_COINTYPE);
+        assertEq(keccak256(retAddr), keccak256(""));
+    }
+
+    function test_continuesWhen_thereIsAlreadyAnAddressStored() public {
+        vm.startPrank(user);
+        // Set resolver to addr resolver address
+        registry.setResolver(fwdNode, address(addrResolver));
+        // Set the ensip-11 network address to user's address
+        addrResolver.setAddr(fwdNode, BASE_COINTYPE, _addressToBytes(user));
+        // Set the legacy addr vield to some new address
+        addrResolver.setAddr(fwdNode, makeAddr("user2"));
+        vm.stopPrank();
+
+        vm.prank(owner);
+        reverse.setBaseForwardAddr(_getNodes());
+
+        address retAddr = _bytesToAddress(addrResolver.addr(fwdNode, BASE_COINTYPE));
+        // Assert that the returned address for the network is the user's address
+        assertEq(retAddr, user);
+    }
+
+    function test_setsTheAddressAsExpected() public {
+        vm.startPrank(user);
+        // Set resolver to addr resolver address
+        registry.setResolver(fwdNode, address(addrResolver));
+        // Set the legacy addr field to user's address
+        addrResolver.setAddr(fwdNode, user);
+        vm.stopPrank();
+
+        vm.prank(owner);
+        reverse.setBaseForwardAddr(_getNodes());
+
+        address retAddr = _bytesToAddress(addrResolver.addr(fwdNode, BASE_COINTYPE));
+        // Assert that the returned address for the network is the user's address
+        assertEq(retAddr, user);
+    }
+
+    function _setupRegistry() internal {
+        bytes32 nameLabel = keccak256("name");
+        vm.prank(owner);
+        registry.setSubnodeOwner(BASE_ETH_NODE, nameLabel, user);
+        fwdNode = keccak256(abi.encodePacked(BASE_ETH_NODE, nameLabel));
+    }
+
+    function _getNodes() internal returns (bytes32[] memory nodes) {
+        nodes = new bytes32[](1);
+        nodes[0] = fwdNode;
+    }
+
+    /// @notice Helper for converting an address stored as bytes into an address type.
+    ///
+    /// @dev Copied from ENS `AddrResolver`:
+    ///     https://github.com/ensdomains/ens-contracts/blob/staging/contracts/resolvers/profiles/AddrResolver.sol
+    ///
+    /// @param b Address bytes.
+    function _bytesToAddress(bytes memory b) internal pure returns (address payable a) {
+        require(b.length == 20);
+        assembly {
+            a := div(mload(add(b, 32)), exp(256, 12))
+        }
+    }
+
+    /// @notice Helper for converting an address into a bytes object.
+    ///
+    /// @dev Copied from ENS `AddrResolver`:
+    ///     https://github.com/ensdomains/ens-contracts/blob/staging/contracts/resolvers/profiles/AddrResolver.sol
+    ///
+    /// @param a Address.
+    function _addressToBytes(address a) internal pure returns (bytes memory b) {
+        b = new bytes(20);
+        assembly {
+            mstore(add(b, 32), mul(a, exp(256, 12)))
+        }
+    }
+}

--- a/test/ReverseRegistrarV2/SetControllerApproval.t.sol
+++ b/test/ReverseRegistrarV2/SetControllerApproval.t.sol
@@ -1,0 +1,30 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ReverseRegistrarV2Base} from "./ReverseRegistrarV2Base.t.sol";
+import {ReverseRegistrar} from "src/L2/ReverseRegistrar.sol";
+import {Ownable} from "solady/auth/Ownable.sol";
+
+contract SetControllerApproval is ReverseRegistrarV2Base {
+    function test_reverts_ifCalledByNonOwner(address caller) public {
+        vm.assume(caller != owner && caller != address(0));
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        reverse.setControllerApproval(caller, true);
+    }
+
+    function test_allowsTheOwner_toUpdateControllerApproval(address newController) public {
+        vm.assume(newController != address(0));
+
+        vm.expectEmit(address(reverse));
+        emit ReverseRegistrar.ControllerApprovalChanged(newController, true);
+        vm.prank(owner);
+        reverse.setControllerApproval(newController, true);
+        assertTrue(reverse.controllers(newController));
+
+        vm.expectEmit(address(reverse));
+        emit ReverseRegistrar.ControllerApprovalChanged(newController, false);
+        vm.prank(owner);
+        reverse.setControllerApproval(newController, false);
+        assertFalse(reverse.controllers(newController));
+    }
+}

--- a/test/ReverseRegistrarV2/SetDefaultResolver.t.sol
+++ b/test/ReverseRegistrarV2/SetDefaultResolver.t.sol
@@ -1,0 +1,30 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {NameResolver} from "ens-contracts/resolvers/profiles/NameResolver.sol";
+import {Ownable} from "solady/auth/Ownable.sol";
+import {ReverseRegistrarV2Base} from "./ReverseRegistrarV2Base.t.sol";
+import {ReverseRegistrarV2} from "src/L2/ReverseRegistrarV2.sol";
+
+contract SetDefaultResolver is ReverseRegistrarV2Base {
+    function test_reverts_whenCalledByNonOwner(address caller) public {
+        vm.assume(caller != owner);
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        vm.prank(caller);
+        reverse.setDefaultResolver(makeAddr("fake"));
+    }
+
+    function test_reverts_whenPassedZeroAddress() public {
+        vm.expectRevert(ReverseRegistrarV2.NoZeroAddress.selector);
+        vm.prank(owner);
+        reverse.setDefaultResolver(address(0));
+    }
+
+    function test_setsTheDefaultResolver() public {
+        vm.expectEmit(address(reverse));
+        emit ReverseRegistrarV2.DefaultResolverChanged(address(resolver));
+        vm.prank(owner);
+        reverse.setDefaultResolver(address(resolver));
+        assertTrue(reverse.defaultResolver() == address(resolver));
+    }
+}

--- a/test/ReverseRegistrarV2/SetName.t.sol
+++ b/test/ReverseRegistrarV2/SetName.t.sol
@@ -7,7 +7,6 @@ import {Sha3} from "src/lib/Sha3.sol";
 import {BASE_REVERSE_NODE} from "src/util/Constants.sol";
 
 contract SetName is ReverseRegistrarV2Base {
-
     function test_setsName() public {
         bytes32 labelHash = Sha3.hexAddress(user);
         bytes32 baseReverseNode = keccak256(abi.encodePacked(BASE_REVERSE_NODE, labelHash));

--- a/test/ReverseRegistrarV2/SetName.t.sol
+++ b/test/ReverseRegistrarV2/SetName.t.sol
@@ -1,0 +1,31 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ReverseRegistrarV2Base} from "./ReverseRegistrarV2Base.t.sol";
+import {ReverseRegistrarV2} from "src/L2/ReverseRegistrarV2.sol";
+import {Sha3} from "src/lib/Sha3.sol";
+import {BASE_REVERSE_NODE} from "src/util/Constants.sol";
+
+contract SetName is ReverseRegistrarV2Base {
+
+    function test_setsName() public {
+        bytes32 labelHash = Sha3.hexAddress(user);
+        bytes32 baseReverseNode = keccak256(abi.encodePacked(BASE_REVERSE_NODE, labelHash));
+
+        string memory name = "name";
+        vm.prank(owner);
+        reverse.setDefaultResolver(address(resolver));
+
+        vm.expectEmit(address(reverse));
+        emit ReverseRegistrarV2.BaseReverseClaimed(user, baseReverseNode);
+        vm.prank(user);
+        bytes32 returnedReverseNode = reverse.setName(name);
+
+        assertTrue(baseReverseNode == returnedReverseNode);
+        address retBaseOwner = registry.owner(baseReverseNode);
+        assertTrue(retBaseOwner == user);
+        address retBaseResolver = registry.resolver(baseReverseNode);
+        assertTrue(retBaseResolver == address(resolver));
+        assertTrue(keccak256(abi.encode(resolver.name(baseReverseNode))) == keccak256(abi.encode(name)));
+    }
+}

--- a/test/ReverseRegistrarV2/SetNameForAddr.t.sol
+++ b/test/ReverseRegistrarV2/SetNameForAddr.t.sol
@@ -1,0 +1,73 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ReverseRegistrarV2Base} from "./ReverseRegistrarV2Base.t.sol";
+import {ReverseRegistrarV2} from "src/L2/ReverseRegistrarV2.sol";
+import {Sha3} from "src/lib/Sha3.sol";
+import {BASE_REVERSE_NODE} from "src/util/Constants.sol";
+import {NameResolver, MockNameResolver} from "test/mocks/MockNameResolver.sol";
+import {MockOwnedContract} from "test/mocks/MockOwnedContract.sol";
+
+contract SetNameForAddr is ReverseRegistrarV2Base {
+    function test_allowsUser_toSetName_forUserAddress() public {
+        bytes32 labelHash = Sha3.hexAddress(user);
+        bytes32 baseReverseNode = keccak256(abi.encodePacked(BASE_REVERSE_NODE, labelHash));
+
+        vm.prank(owner);
+        reverse.setDefaultResolver(address(resolver));
+
+        vm.expectEmit(address(reverse));
+        emit ReverseRegistrarV2.BaseReverseClaimed(user, baseReverseNode);
+        vm.prank(user);
+        bytes32 returnedReverseNode = reverse.setNameForAddr(user, user, address(resolver), name);
+
+        assertTrue(baseReverseNode == returnedReverseNode);
+        address retBaseOwner = registry.owner(baseReverseNode);
+        assertTrue(retBaseOwner == user);
+        address retBaseResolver = registry.resolver(baseReverseNode);
+        assertTrue(retBaseResolver == address(resolver));
+        assertTrue(keccak256(abi.encode(resolver.name(baseReverseNode))) == keccak256(abi.encode(name)));
+    }
+
+    function test_allowsOperator_toSetName_forUserAddress() public {
+        bytes32 labelHash = Sha3.hexAddress(user);
+        bytes32 baseReverseNode = keccak256(abi.encodePacked(BASE_REVERSE_NODE, labelHash));
+
+        address operator = makeAddr("operator");
+        vm.prank(user);
+        registry.setApprovalForAll(operator, true);
+
+        vm.prank(owner);
+        reverse.setDefaultResolver(address(resolver));
+
+        vm.expectEmit(address(reverse));
+        emit ReverseRegistrarV2.BaseReverseClaimed(user, baseReverseNode);
+        vm.prank(operator);
+        bytes32 returnedReverseNode = reverse.setNameForAddr(user, user, address(resolver), name);
+
+        assertTrue(baseReverseNode == returnedReverseNode);
+        address retBaseOwner = registry.owner(baseReverseNode);
+        assertTrue(retBaseOwner == user);
+        address retBaseResolver = registry.resolver(baseReverseNode);
+        assertTrue(retBaseResolver == address(resolver));
+        assertTrue(keccak256(abi.encode(resolver.name(baseReverseNode))) == keccak256(abi.encode(name)));
+    }
+
+    function test_allowsOwnerOfContract_toSetName_forOwnedContractAddress() public {
+        MockOwnedContract ownedContract = new MockOwnedContract(user);
+        bytes32 labelHash = Sha3.hexAddress(address(ownedContract));
+        bytes32 baseReverseNode = keccak256(abi.encodePacked(BASE_REVERSE_NODE, labelHash));
+
+        vm.expectEmit(address(reverse));
+        emit ReverseRegistrarV2.BaseReverseClaimed(address(ownedContract), baseReverseNode);
+        vm.prank(user);
+        bytes32 returnedReverseNode = reverse.setNameForAddr(address(ownedContract), user, address(resolver), name);
+
+        assertTrue(baseReverseNode == returnedReverseNode);
+        address retBaseOwner = registry.owner(baseReverseNode);
+        assertTrue(retBaseOwner == user);
+        address retBaseResolver = registry.resolver(baseReverseNode);
+        assertTrue(retBaseResolver == address(resolver));
+        assertTrue(keccak256(abi.encode(resolver.name(baseReverseNode))) == keccak256(abi.encode(name)));
+    }
+}

--- a/test/ReverseRegistrarV2/SetNameForAddrWithSignature.t.sol
+++ b/test/ReverseRegistrarV2/SetNameForAddrWithSignature.t.sol
@@ -13,7 +13,7 @@ contract SetNameForAddrWithSignature is ReverseRegistrarV2Base {
         uint256[] memory cointypes = new uint256[](1);
         cointypes[0] = BASE_COINTYPE;
         bytes memory signature = "";
-        uint256 expiry = block.timestamp + 5 minutes; 
+        uint256 expiry = block.timestamp + 5 minutes;
 
         vm.prank(owner);
         reverse.setDefaultResolver(address(resolver));
@@ -24,8 +24,7 @@ contract SetNameForAddrWithSignature is ReverseRegistrarV2Base {
         vm.expectCall(
             address(l2ReverseRegistrar),
             abi.encodeCall(
-                MockL2ReverseRegistrar.setNameForAddrWithSignature,
-                (user, expiry, name, cointypes, signature)
+                MockL2ReverseRegistrar.setNameForAddrWithSignature, (user, expiry, name, cointypes, signature)
             )
         );
         vm.prank(user);

--- a/test/ReverseRegistrarV2/SetNameForAddrWithSignature.t.sol
+++ b/test/ReverseRegistrarV2/SetNameForAddrWithSignature.t.sol
@@ -1,0 +1,36 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ReverseRegistrarV2} from "src/L2/ReverseRegistrarV2.sol";
+import {ReverseRegistrarV2Base} from "./ReverseRegistrarV2Base.t.sol";
+import {MockL2ReverseRegistrar} from "test/mocks/MockL2ReverseRegistrar.sol";
+import {MockReverseRegistrar} from "test/mocks/MockReverseRegistrar.sol";
+import {BASE_REVERSE_NODE} from "src/util/Constants.sol";
+import {Sha3} from "src/lib/Sha3.sol";
+
+contract SetNameForAddrWithSignature is ReverseRegistrarV2Base {
+    function test_setsNameForAddrWithSignature() public {
+        uint256[] memory cointypes = new uint256[](1);
+        cointypes[0] = BASE_COINTYPE;
+        bytes memory signature = "";
+        uint256 expiry = block.timestamp + 5 minutes; 
+
+        vm.prank(owner);
+        reverse.setDefaultResolver(address(resolver));
+
+        bytes32 labelHash = Sha3.hexAddress(user);
+        bytes32 baseReverseNode = keccak256(abi.encodePacked(BASE_REVERSE_NODE, labelHash));
+
+        vm.expectCall(
+            address(l2ReverseRegistrar),
+            abi.encodeCall(
+                MockL2ReverseRegistrar.setNameForAddrWithSignature,
+                (user, expiry, name, cointypes, signature)
+            )
+        );
+        vm.prank(user);
+
+        bytes32 revNode = reverse.setNameForAddrWithSignature(user, name, expiry, cointypes, signature);
+        assertEq(revNode, baseReverseNode);
+    }
+}

--- a/test/ReverseRegistrarV2/SetNameForAddrWithSignature.t.sol
+++ b/test/ReverseRegistrarV2/SetNameForAddrWithSignature.t.sol
@@ -29,7 +29,7 @@ contract SetNameForAddrWithSignature is ReverseRegistrarV2Base {
         );
         vm.prank(user);
 
-        bytes32 revNode = reverse.setNameForAddrWithSignature(user, name, expiry, cointypes, signature);
+        bytes32 revNode = reverse.setNameForAddrWithSignature(user, expiry, name, cointypes, signature);
         assertEq(revNode, baseReverseNode);
     }
 }

--- a/test/mocks/MockAddrResolver.sol
+++ b/test/mocks/MockAddrResolver.sol
@@ -1,0 +1,10 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {AddrResolver} from "ens-contracts/resolvers/profiles/AddrResolver.sol";
+
+contract MockAddrResolver is AddrResolver {
+    function isAuthorised(bytes32) internal pure override returns (bool) {
+        return true;
+    }
+}

--- a/test/mocks/MockL2ReverseRegistrar.sol
+++ b/test/mocks/MockL2ReverseRegistrar.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+contract MockL2ReverseRegistrar {
+    /// @notice Sets the `nameForAddr()` record for the addr provided account using a signature.
+    ///
+    /// @param addr The address to set the name for.
+    /// @param name The name to set.
+    /// @param coinTypes The coin types to set. Must be inclusive of the coin type for the contract.
+    /// @param signatureExpiry Date when the signature expires.
+    /// @param signature The signature from the addr.
+    function setNameForAddrWithSignature(
+        address addr,
+        uint256 signatureExpiry,
+        string memory name,
+        uint256[] memory coinTypes,
+        bytes memory signature
+    ) external {}
+}


### PR DESCRIPTION
To fully support ENSIP-19,  two data migrations are needed: 
1. Our users' fwd resolution data needs to be set against the base network-specific cointype (per ENSIP-11). 
2. Our users' reverse resolution data needs to be stored in the ENS deployed L2ReverseRegistrar.

To address number 1, an owner-only hook has been added which allows the basenames admin to write ENSIP-11 data on behalf of existing basenames. 
 
To address number 2 and to ensure data is not lost in the migration process, the reverse data will be written during the migration period to both the legacy resolver and to the new ENS contract. 