### PR TITLE
June '25 Audit Fixes

### DIFF
--- a/src/L2/UpgradeableRegistrarController.sol
+++ b/src/L2/UpgradeableRegistrarController.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 import {EnumerableSetLib} from "solady/utils/EnumerableSetLib.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {IMulticallable} from "ens-contracts/resolvers/IMulticallable.sol";
-import {OwnableUpgradeable} from "openzeppelin-contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "openzeppelin-contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {StringUtils} from "ens-contracts/ethregistrar/StringUtils.sol";
 
@@ -27,7 +27,7 @@ import {IRegistrarController} from "./interface/IRegistrarController.sol";
 ///         https://github.com/ensdomains/ens-contracts/blob/staging/contracts/ethregistrar/ETHRegistrarController.sol
 ///
 /// @author Coinbase (https://github.com/base/basenames)
-contract UpgradeableRegistrarController is OwnableUpgradeable {
+contract UpgradeableRegistrarController is Ownable2StepUpgradeable {
     using StringUtils for *;
     using SafeERC20 for IERC20;
     using EnumerableSetLib for EnumerableSetLib.Bytes32Set;

--- a/src/L2/UpgradeableRegistrarController.sol
+++ b/src/L2/UpgradeableRegistrarController.sol
@@ -249,15 +249,18 @@ contract UpgradeableRegistrarController is OwnableUpgradeable {
     /// @notice Decorator for validating discounted registrations.
     ///
     /// @dev Validates that:
-    ///     1. That the registrant has not already registered with a discount
-    ///     2. That the discount is `active`
+    ///     1. That the registrant has not already registered with a discount.
+    ///     2. That the discount is `active`.
     ///     3. That the associated `discountValidator` returns true when `isValidDiscountRegistration` is called.
     ///
     /// @param discountKey The uuid of the discount.
     /// @param validationData The associated validation data for this discount registration.
     modifier validDiscount(bytes32 discountKey, bytes calldata validationData) {
         URCStorage storage $ = _getURCStorage();
-        if ($.discountedRegistrants[msg.sender]) revert AlreadyRegisteredWithDiscount(msg.sender);
+        if (
+            $.discountedRegistrants[msg.sender]
+                || RegistrarController($.legacyRegistrarController).discountedRegistrants(msg.sender)
+        ) revert AlreadyRegisteredWithDiscount(msg.sender);
         DiscountDetails memory details = $.discounts[discountKey];
 
         if (!details.active) revert InactiveDiscount(discountKey);

--- a/src/L2/UpgradeableRegistrarController.sol
+++ b/src/L2/UpgradeableRegistrarController.sol
@@ -383,11 +383,9 @@ contract UpgradeableRegistrarController is OwnableUpgradeable {
     /// @return `true` if any of the addresses have already registered with a discount, else `false`.
     function hasRegisteredWithDiscount(address[] memory addresses) external view returns (bool) {
         URCStorage storage $ = _getURCStorage();
+        if (RegistrarController($.legacyRegistrarController).hasRegisteredWithDiscount(addresses)) return true;
         for (uint256 i; i < addresses.length; i++) {
-            if (
-                $.discountedRegistrants[addresses[i]]
-                    || RegistrarController($.legacyRegistrarController).hasRegisteredWithDiscount(addresses)
-            ) {
+            if ($.discountedRegistrants[addresses[i]]) {
                 return true;
             }
         }

--- a/src/L2/interface/IBaseRegistrar.sol
+++ b/src/L2/interface/IBaseRegistrar.sol
@@ -11,6 +11,13 @@ interface IBaseRegistrar {
     // Authorises a controller, who can register and renew domains.
     function addController(address controller) external;
 
+    /// @notice Returns true if the specified name is available for registration.
+    ///
+    /// @param id The id of the name to check availability of.
+    ///
+    /// @return `true` if the name is available, else `false`.
+    function isAvailable(uint256 id) external view returns (bool);
+
     // Revoke controller permission for an address.
     function removeController(address controller) external;
 
@@ -27,6 +34,17 @@ interface IBaseRegistrar {
      * @dev Register a name.
      */
     function register(uint256 id, address owner, uint256 duration) external returns (uint256);
+
+    /// @notice Register a name and add details to the record in the Registry.
+    ///
+    /// @param id The token id determined by keccak256(label).
+    /// @param owner The address that should own the registration.
+    /// @param duration Duration in seconds for the registration.
+    /// @param resolver Address of the resolver for the name.
+    /// @param ttl Time-to-live for the name.
+    function registerWithRecord(uint256 id, address owner, uint256 duration, address resolver, uint64 ttl)
+        external
+        returns (uint256);
 
     function renew(uint256 id, uint256 duration) external returns (uint256);
 

--- a/src/L2/interface/IRegistrarController.sol
+++ b/src/L2/interface/IRegistrarController.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+interface IRegistrarController {
+    /// @notice Getter method for checking whether an address has registered with a discount.
+    ///
+    /// @param registrant The address of the registrant.
+    ///
+    /// @return hasRegisteredWithDiscount Returns `true` if the registrant has previously claimed a discount, else `false`.
+    function discountedRegistrants(address registrant) external returns (bool hasRegisteredWithDiscount);
+
+    /// @notice Checks whether any of the provided addresses have registered with a discount.
+    ///
+    /// @param addresses The array of addresses to check for discount registration.
+    ///
+    /// @return `true` if any of the addresses have already registered with a discount, else `false`.
+    function hasRegisteredWithDiscount(address[] memory addresses) external view returns (bool);
+}

--- a/src/L2/interface/IRegistrarController.sol
+++ b/src/L2/interface/IRegistrarController.sol
@@ -7,7 +7,7 @@ interface IRegistrarController {
     /// @param registrant The address of the registrant.
     ///
     /// @return hasRegisteredWithDiscount Returns `true` if the registrant has previously claimed a discount, else `false`.
-    function discountedRegistrants(address registrant) external returns (bool hasRegisteredWithDiscount);
+    function discountedRegistrants(address registrant) external returns (bool);
 
     /// @notice Checks whether any of the provided addresses have registered with a discount.
     ///

--- a/test/mocks/MockRegistrarController.sol
+++ b/test/mocks/MockRegistrarController.sol
@@ -22,5 +22,6 @@ contract MockRegistrarController {
 
     function setHasRegisteredWithDiscount(address addr, bool status) external {
         hasRegistered[addr] = status;
+        discountedRegistrants[addr] = status;
     }
 }

--- a/test/mocks/MockRegistrarController.sol
+++ b/test/mocks/MockRegistrarController.sol
@@ -5,6 +5,8 @@ contract MockRegistrarController {
     mapping(address => bool) hasRegistered;
     uint256 public launchTime;
 
+    mapping(address => bool) public discountedRegistrants;
+
     constructor(uint256 launchTime_) {
         launchTime = launchTime_;
     }


### PR DESCRIPTION
Changes made:

Finding 1) `legacyRegistrarController.hasRegisteredWithDiscount() is executed multiple times redundantly`
Move call to legacy registrar controller `hasRegisteredWithDiscount` out of the `for` loop. 

Finding 2) `Users who used their one-time discount in the legacy registrar will be able to use it again after the upgrade`
Add a call in `validDiscount` to check legacy registrar controller `discountedRegistrants` mapping.

Finding 5) `RegistrarController, BaseRegistrar, L2Resolver are imported but only used for their interfaces`
Add necessary interfaces to support replacing imports of full contracts to lightweight interfaces.

Finding 8) `consider using Ownable2Step`
Replace inherited ownership to OZ's Ownable2StepUpgradeable contract. 