### PR TITLE
Add Migration Controller

### DIFF
--- a/src/L2/MigrationController.sol
+++ b/src/L2/MigrationController.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {AddrResolver} from "ens-contracts/resolvers/profiles/AddrResolver.sol";
+import {ENS} from "ens-contracts/registry/ENS.sol";
+import {Ownable2Step, Ownable} from "openzeppelin-contracts/contracts/access/Ownable2Step.sol";
+
+/// @title Migration Controller
+///
+/// @notice Helper controller for migrating user address data from the vestigial `addr` space to the ENSIP-11 compliant
+///     network-as-cointype format.
+///
+/// @author Coinbase (https://github.com/base/basenames)
+contract MigrationController is Ownable2Step {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          STORAGE                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice The Registry contract.
+    ENS public immutable registry;
+
+    /// @notice The ENSIP-11 network as coinType.
+    uint256 public immutable coinType;
+
+    /// @notice The legacy Basenames l2Resolver for setting Name resolution records.
+    address public l2Resolver;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        IMPLEMENTATION                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    constructor(ENS registry_, uint256 coinType_, address l2Resolver_, address owner_) Ownable(owner_) {
+        registry = registry_;
+        coinType = coinType_;
+        l2Resolver = l2Resolver_;
+    }
+
+    /// @notice Allows the owner to back populate the ENSIP-11 forward resolution records for Basenames.
+    ///
+    /// @dev For each node in `nodes` we make a series of checks to make sure that we're
+    ///     1. Trying to set data against our L2Resolver contract.
+    ///     2. Setting a valid forward resolution address.
+    ///     3. Not overwriting an existing value.
+    ///     If any of these checks fails, we skip this node and continue.
+    ///
+    /// @param nodes The array of nodes for which records will be set.
+    function setBaseForwardAddr(bytes32[] memory nodes) public onlyOwner {
+        for (uint256 i; i < nodes.length; i++) {
+            bytes32 _node = nodes[i];
+
+            // Get the resolver address for the node and check that it is our public resolver.
+            address resolverAddr = registry.resolver(_node);
+            if (resolverAddr != l2Resolver) continue;
+            AddrResolver resolver = AddrResolver(resolverAddr);
+
+            // Get the `addr` record for the node and check validity.
+            address resolvedAddr = resolver.addr(_node);
+            if (resolvedAddr == address(0)) continue;
+
+            // Check if there is an ENSIP-11 cointype address already set for this node.
+            if (resolver.addr(_node, coinType).length != 0) continue;
+
+            // Set the ENSIP-11 forward resolution addr.
+            resolver.setAddr(_node, coinType, _addressToBytes(resolvedAddr));
+        }
+    }
+
+    /// @notice Helper for converting an address into a bytes object.
+    ///
+    /// @dev Copied from ENS `AddrResolver`:
+    ///     https://github.com/ensdomains/ens-contracts/blob/staging/contracts/resolvers/profiles/AddrResolver.sol
+    ///
+    /// @param a Address.
+    function _addressToBytes(address a) internal pure returns (bytes memory b) {
+        b = new bytes(20);
+        assembly {
+            mstore(add(b, 32), mul(a, exp(256, 12)))
+        }
+    }
+}

--- a/test/Integration/ForwardResolutionMigration.t.sol
+++ b/test/Integration/ForwardResolutionMigration.t.sol
@@ -1,0 +1,39 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {IntegrationTestBase} from "./IntegrationTestBase.t.sol";
+import {MigrationController} from "src/L2/MigrationController.sol";
+
+contract ForwardResolutionMigration is IntegrationTestBase {
+    MigrationController migrationController;
+    uint256 BASE_COINTYPE = 0x80002105;
+    bytes32 aliceNode;
+
+    function setUp() public override {
+        super.setUp();
+        migrationController = new MigrationController(registry, BASE_COINTYPE, address(defaultL2Resolver), owner);
+
+        aliceNode = _registerAlice();
+    }
+
+    function test_allowsTheOwnerToMigrateAUser() public {
+        vm.startPrank(owner);
+        defaultL2Resolver.setRegistrarController(address(migrationController));
+
+        bytes32[] memory nodes = new bytes32[](1);
+        nodes[0] = aliceNode;
+
+        migrationController.setBaseForwardAddr(nodes);
+
+        bytes memory aliceAddr = defaultL2Resolver.addr(aliceNode, BASE_COINTYPE);
+
+        assertEq(_bytesToAddress(aliceAddr), alice);
+    }
+
+    function _bytesToAddress(bytes memory b) internal pure returns (address payable a) {
+        require(b.length == 20);
+        assembly {
+            a := div(mload(add(b, 32)), exp(256, 12))
+        }
+    }
+}

--- a/test/MigrationController/MigrationControllerBase.t.sol
+++ b/test/MigrationController/MigrationControllerBase.t.sol
@@ -1,0 +1,85 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {MigrationController} from "src/L2/MigrationController.sol";
+import {MockAddrResolver} from "test/mocks/MockAddrResolver.sol";
+import {NameEncoder} from "ens-contracts/utils/NameEncoder.sol";
+import {Registry} from "src/L2/Registry.sol";
+import {Test} from "forge-std/Test.sol";
+
+import {ETH_NODE, BASE_ETH_NODE, REVERSE_NODE, BASE_REVERSE_NODE, BASE_ETH_NAME} from "src/util/Constants.sol";
+
+contract MigrationControllerBase is Test {
+    MigrationController migrationController;
+    Registry registry;
+    MockAddrResolver resolver;
+
+    uint256 constant BASE_COINTYPE = 0x80002105;
+    bytes32 constant ROOT_NODE = bytes32(0);
+    bytes32 constant ETH_LABEL = 0x4f5b812789fc606be1b3b16908db13fc7a9adf7ca72641f84d75b47069d3d7f0;
+    bytes32 constant BASE_LABEL = 0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f;
+
+    address owner = makeAddr("owner");
+    address alice = makeAddr("alice");
+
+    string aliceName = "alice";
+    string fullAliceName = "alice.base.eth";
+    bytes32 aliceNode;
+    bytes32 aliceLabel;
+
+    function setUp() public {
+        aliceLabel = keccak256(bytes(aliceName));
+        (, aliceNode) = NameEncoder.dnsEncodeName(fullAliceName);
+
+        registry = new Registry(owner);
+
+        resolver = new MockAddrResolver();
+        _establishNamespace();
+
+        migrationController = new MigrationController(registry, BASE_COINTYPE, address(resolver), owner);
+    }
+
+    function _establishNamespace() internal {
+        // establish base.eth namespace and assign ownership of base.eth to the owner
+        vm.startPrank(owner);
+        registry.setSubnodeOwner(ROOT_NODE, ETH_LABEL, owner);
+        registry.setSubnodeOwner(ETH_NODE, BASE_LABEL, owner);
+        vm.stopPrank();
+    }
+
+    // alice.base.eth to alice with resolver.
+    function _setupAliceNode() internal {
+        vm.prank(owner);
+        registry.setSubnodeRecord(BASE_ETH_NODE, aliceLabel, alice, address(resolver), 0);
+    }
+
+    function _createAddrResolverRecord() internal {
+        vm.prank(alice);
+        resolver.setAddr(aliceNode, alice);
+    }
+
+    function _createBaseAddrResolverRecord() internal {
+        vm.prank(alice);
+        resolver.setAddr(aliceNode, BASE_COINTYPE, addressToBytes(alice));
+    }
+
+    function _getNodesArray() internal view returns (bytes32[] memory) {
+        bytes32[] memory nodes = new bytes32[](1);
+        nodes[0] = aliceNode;
+        return nodes;
+    }
+
+    function bytesToAddress(bytes memory b) internal pure returns (address payable a) {
+        require(b.length == 20);
+        assembly {
+            a := div(mload(add(b, 32)), exp(256, 12))
+        }
+    }
+
+    function addressToBytes(address a) internal pure returns (bytes memory b) {
+        b = new bytes(20);
+        assembly {
+            mstore(add(b, 32), mul(a, exp(256, 12)))
+        }
+    }
+}

--- a/test/MigrationController/SetBaseForwardAddr.t.sol
+++ b/test/MigrationController/SetBaseForwardAddr.t.sol
@@ -1,0 +1,54 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {MigrationControllerBase} from "./MigrationControllerBase.t.sol";
+import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+
+contract SetBaseForwardAddr is MigrationControllerBase {
+    function test_revertsWhen_calledByNonOwner(address caller) public {
+        vm.assume(caller != owner);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, caller));
+        vm.prank(caller);
+        migrationController.setBaseForwardAddr(new bytes32[](1));
+    }
+
+    function test_continuesWhenTheResolverIsNotTheDefaultResolver() public {
+        _setupAliceNode();
+        vm.prank(alice);
+        registry.setResolver(aliceNode, makeAddr("newResolver"));
+
+        vm.prank(owner);
+        migrationController.setBaseForwardAddr(_getNodesArray());
+
+        assertEq(resolver.addr(aliceNode, BASE_COINTYPE), "");
+    }
+
+    function test_continuesWhenTheAddrRecordIsNotSet() public {
+        _setupAliceNode();
+
+        vm.prank(owner);
+        migrationController.setBaseForwardAddr(_getNodesArray());
+
+        assertEq(resolver.addr(aliceNode, BASE_COINTYPE), "");
+    }
+
+    function test_continuesWhenAnEnsip11AddressIsAlreadySet() public {
+        _setupAliceNode();
+        _createBaseAddrResolverRecord();
+
+        vm.prank(owner);
+        migrationController.setBaseForwardAddr(_getNodesArray());
+
+        assertEq(bytesToAddress(resolver.addr(aliceNode, BASE_COINTYPE)), alice);
+    }
+
+    function test_setsTheEnsip11AddressCorrectly() public {
+        _setupAliceNode();
+        _createAddrResolverRecord();
+
+        vm.prank(owner);
+        migrationController.setBaseForwardAddr(_getNodesArray());
+
+        assertEq(bytesToAddress(resolver.addr(aliceNode, BASE_COINTYPE)), alice);
+    }
+}


### PR DESCRIPTION
Our strategy for migrating to ENSIP-19 compliance requires a migration of user forward resolution data from the legacy `60` cointype to an ENSIP-11 network-as-cointype schema. Initially, this was going to be accomplished with our ReverseRegistrarV2, however, we are no longer going to use that contract. In its place, we still need a permissioned controller contract that can complete the forward resolution migration. 

This singleton uses the same validated/audited logic as ReverseRegistrarV2 to perform said migration. 